### PR TITLE
Fix for key heights and width smaller than 1 unit

### DIFF
--- a/showOutput3.js
+++ b/showOutput3.js
@@ -684,7 +684,7 @@ document.getElementById('submit').addEventListener(
         for ( row = 0; row < matrix_rows; row++ ) {
             matrix[row] = new Array(matrix_cols);
             for ( col = 0; col < matrix_cols; col++ ) {
-                matrix[row][col] = "KC_NO";
+                matrix[row][col] = "XXX";
             }
         }
         //console.log( matrix );
@@ -708,6 +708,8 @@ document.getElementById('submit').addEventListener(
             "#pragma once",
             "",
             "#include \"quantum.h\"",
+            "",
+            "#define XXX KC_NO",
             "",
             "#define LAYOUT( \\",
             ") { \\",
@@ -952,7 +954,7 @@ document.getElementById('submit').addEventListener(
                 } else {
                     console.error( "keycode "+ append +" not recognized!" );
                 }
-                matrix[matrixRow][matrixCol] = "K"+ base32hex.substr( obj.keyboard.keys[key].row , 1) + base32hex.substr( obj.keyboard.keys[key].col , 1) +"  ";
+                matrix[matrixRow][matrixCol] = "K"+ base32hex.substr( obj.keyboard.keys[key].row , 1) + base32hex.substr( obj.keyboard.keys[key].col , 1);
             }
             layerData_suffix = "    ),";
 
@@ -1175,11 +1177,11 @@ document.getElementById('submit').addEventListener(
         );
 
         for ( i = matrix_rows-1; i >= 0; i-- ) {
-            // inserts Electrical Switch Matrix at index 21 (22nd line)
-            layoutMacroOutput.splice(22, 0, "    { "+ matrix[i].join(', ').replace(/( +),/g, ",$1") +" }, \\" );
+            // inserts Electrical Switch Matrix at index 24 (25th line)
+            layoutMacroOutput.splice(24, 0, "    { "+ matrix[i].join(', ').replace(/( +),/g, ",$1") +" }, \\" );
         }
-        // inserts Physical Switch Matrix at index 20
-        layoutMacroOutput.splice(21, 0, layoutMacro);
+        // inserts Physical Switch Matrix at index 23
+        layoutMacroOutput.splice(23, 0, layoutMacro);
 
 
         /**********************************************

--- a/showOutput3.js
+++ b/showOutput3.js
@@ -40,6 +40,16 @@ String.prototype.replaceBetween = function(start, end, new_string) {
 };
 
 
+/**
+ * @brief round a floating point number
+ *   i : number to round
+ *   p : points of precision
+ */
+function fp_round(i, p) {
+    return Math.round( i * Math.pow(10, p) ) / Math.pow(10, p);
+};
+
+
 document.getElementById("c_config").addEventListener(
     "click",
     function(){
@@ -1010,12 +1020,12 @@ document.getElementById('submit').addEventListener(
         var keyObjects = new Array(keyCount);
         for ( key=0; key<keyCount; key++ ) {
             // Key Dimensions and Positioning
-            var w = obj.keyboard.keys[key].state.w;
-            var h = obj.keyboard.keys[key].state.h;
-            var x = obj.keyboard.keys[key].state.x;
+            var w = fp_round( obj.keyboard.keys[key].state.w , 3 );
+            var h = fp_round( obj.keyboard.keys[key].state.h , 3 );
+            var x = fp_round( obj.keyboard.keys[key].state.x , 3 );
             // check y-axis vertical offset (handling vertically-offset keys)
-            var y = Math.floor( obj.keyboard.keys[key].state.y );
-            var yo = obj.keyboard.keys[key].state.y - y;
+            var y = fp_round( obj.keyboard.keys[key].state.y , 3 );
+            //var yo = obj.keyboard.keys[key].state.y - y;
 
             // Electrical Data
             var pinRow = obj.keyboard.pins.row[obj.keyboard.keys[key].row];

--- a/showOutput3.js
+++ b/showOutput3.js
@@ -1009,9 +1009,9 @@ document.getElementById('submit').addEventListener(
         ** CREATE LAYOUT CONTAINER **
         ****************************/
         //var layoutMacro = new Array( keymapHeight );
-        var layoutMacro = "";
+        var layoutMacro = "    ";
         for ( i=0 ; i<keymapHeight; i++ ) {
-            layoutMacro += " ".repeat( ( keymapWidth * 5 ) + 4 ) + "\\";
+            layoutMacro += " \\";
         }
         var layoutMacro_rowOffset = ( keymapWidth * 5 ) + 5;
         //console.log( layoutMacro );
@@ -1034,31 +1034,37 @@ document.getElementById('submit').addEventListener(
             var pinCol = obj.keyboard.pins.col[obj.keyboard.keys[key].col];
             var label = ["K", base32hex.substr(obj.keyboard.keys[key].row, 1), base32hex.substr(obj.keyboard.keys[key].col, 1)].join('') + " ("+ [pinRow,pinCol].join(',') +")";
 
-            var pos = y +"."+ ( x / 100 ).toString().replace(/\./g, "");
-            keyObject = new Array( pos, y, x, yo, label, w, h );
+            keyObject = new Array(
+                key,
+                '"y": '+ y,
+                '"x": '+ x,
+                '"label": "'+ label +'"',
+                '"w": '+ w,
+                '"h": '+ h
+            );
             //console.log ( "y,yo -> "+ y +","+ yo +" | "+ keyObject.join(', ') );
 
             if ( h == 1 ) {
-                //keyObject.splice(6, 1);
+                keyObject.splice(5, 1);
             }
             if ( w == 1 ) {
-                //keyObject.splice(5, 1);
+                keyObject.splice(4, 1);
             }
 
             keyObjects[key] = keyObject.join('\t');
 
             infojsonOutput.push(
                 [
-                    "{\"label\":\""+ [
+                    "{\"label\": \""+ [
                         "K",
                         base32hex.substr(obj.keyboard.keys[key].row, 1),
                         base32hex.substr(obj.keyboard.keys[key].col, 1)
                     ].join('') +
                     " (" + pinRow +"," + pinCol +")"+
                     "\"",
-                    "\"x\":"+ x,
-                    "\"y\":"+ y,
-                    "\"yo\":"+ yo +"},"
+                    "\"x\": "+ x,
+                    "\"y\": "+ y/*,
+                    "\"yo\": "+ yo*/ +"},"
                     /*"\"offset\":"+ vOffset + */
                 ].join(', ')
             );
@@ -1148,26 +1154,27 @@ document.getElementById('submit').addEventListener(
             }
 
             //build physical layout macro
-            if ( keyObjects[key][3] >= 6 ) {
+            if ( keyObjects[key][3] >= 6000 ) {
                 // A key this long is probably a spacebar, so handle it differently
                 layoutMacro_start = (
                     /* V Offset */
                     Number( Math.floor( keyObjects[key][0] ) * layoutMacro_rowOffset ) +
                     /* H Offset */
-                    ( keyObjects[key][1] * 5 ) + Math.floor( keyObjects[key][3] * 2 )
+                    ( keyObjects[key][1] * 5 ) + Math.round( keyObjects[key][3] * 2 )
                 );
             } else {
-                layoutMacro_start = ( Number( Math.floor( keyObjects[key][0] ) * layoutMacro_rowOffset ) + ( keyObjects[key][1] * 5 ) );
+                //layoutMacro_start = ( Number( Math.round( keyObjects[key][0] ) * layoutMacro_rowOffset ) + ( keyObjects[key][1] * 5 ) );
+                layoutMacro += keyObjects[key][0];
             }
-            layoutMacro_end = Number(layoutMacro_start + 5);
-            layoutMacro = layoutMacro.replaceBetween( layoutMacro_start, layoutMacro_end, keyObjects[key][2].replace(/ \(.*/, "")+", " );
+            //layoutMacro_end = Number(layoutMacro_start + 5);
+            //layoutMacro = layoutMacro.replaceBetween( layoutMacro_start, layoutMacro_end, keyObjects[key][2].replace(/ \(.*/, "")+", " );
         }
         //console.log( "^" + layoutMacro + "$" );
-        layoutMacro = "    "+ layoutMacro
-            .replace(/,( +)\\$/g, " $1\\")
+        //layoutMacro = "    "+ layoutMacro
+            /*.replace(/,( +)\\$/g, " $1\\")
             .replace(/\\/g, "\\\n    ")
             .replace(/\\\n    $/g, "\\")
-            .replace(/  \\/g, "\\")
+            .replace(/  \\/g, "\\")*/
         ;
         //physicalMatrix = physicalMatrix.replace(/, \\$/, "")
 

--- a/showOutput3.js
+++ b/showOutput3.js
@@ -642,15 +642,6 @@ document.getElementById('submit').addEventListener(
         /***************
         ** keyboard.c **
         ***************/
-        var matrix = new Array(matrix_rows);
-
-        for ( row = 0; row < matrix_rows; row++ ) {
-            matrix[row] = new Array(matrix_cols);
-            for ( col = 0; col < matrix_cols; col++ ) {
-                matrix[row][col] = "KC_NO";
-            }
-        }
-        //console.log( matrix );
         var keyboardCOutput = [
             "/* Copyright "+ year +" REPLACE_WITH_YOUR_NAME",
             " *",

--- a/showOutput3.js
+++ b/showOutput3.js
@@ -1035,14 +1035,13 @@ document.getElementById('submit').addEventListener(
             var label = ["K", base32hex.substr(obj.keyboard.keys[key].row, 1), base32hex.substr(obj.keyboard.keys[key].col, 1)].join('') + " ("+ [pinRow,pinCol].join(',') +")";
 
             keyObject = new Array(
-                key,
-                '"y": '+ y,
-                '"x": '+ x,
                 '"label": "'+ label +'"',
+                '"seq": "'+ key +'"',
+                '"x": '+ x,
+                '"y": '+ y,
                 '"w": '+ w,
                 '"h": '+ h
             );
-            //console.log ( "y,yo -> "+ y +","+ yo +" | "+ keyObject.join(', ') );
 
             if ( h == 1 ) {
                 keyObject.splice(5, 1);
@@ -1051,22 +1050,11 @@ document.getElementById('submit').addEventListener(
                 keyObject.splice(4, 1);
             }
 
+            //console.log( keyObject.join('\t') );
             keyObjects[key] = keyObject.join('\t');
 
             infojsonOutput.push(
-                [
-                    "{\"label\": \""+ [
-                        "K",
-                        base32hex.substr(obj.keyboard.keys[key].row, 1),
-                        base32hex.substr(obj.keyboard.keys[key].col, 1)
-                    ].join('') +
-                    " (" + pinRow +"," + pinCol +")"+
-                    "\"",
-                    "\"x\": "+ x,
-                    "\"y\": "+ y/*,
-                    "\"yo\": "+ yo*/ +"},"
-                    /*"\"offset\":"+ vOffset + */
-                ].join(', ')
+                " ".repeat(16) + "{" + keyObject.join(', ') + "},"
             );
 
             if ( w != 1 ) {
@@ -1127,29 +1115,6 @@ document.getElementById('submit').addEventListener(
             keyObjects[key][0] = Number( keyObjects[key][0] ) + Number( keyObjects[key][2] );
             keyObjects[key].splice(2, 1);
 
-            var infojsonOutputArray = [
-                "\"label\":\""+ keyObjects[key][2] +"\"",
-                "\"x\":"+ keyObjects[key][1],
-                "\"y\":"+ keyObjects[key][0],
-                "\"w\":"+ keyObjects[key][3],
-                "\"h\":"+ keyObjects[key][4]
-            ];
-            if ( keyObjects[key][4] == 1 ) {
-                infojsonOutputArray.splice(4, 1);
-            }
-            if ( keyObjects[key][3] == 1 ) {
-                infojsonOutputArray.splice(3, 1);
-            }
-            // key output starts at `infojsonPreambleLines`+1
-            infojsonOutput[key+infojsonPreambleLines] = "{" + infojsonOutputArray.join(', ') +
-                /*[
-                    "\"label\":\""+ keyObjects[key][2] +"\"",
-                    "\"x\":"+ keyObjects[key][1],
-                    "\"y\":"+ keyObjects[key][0],
-                    "\"w\":"+ keyObjects[key][3],
-                    "\"h\":"+ keyObjects[key][4]
-                ].join(', ') +*/
-                "},";
             if ( key == ( keyCount-1 ) ) {
             }
 
@@ -1262,10 +1227,11 @@ document.getElementById('submit').addEventListener(
                                 //         ┌ there are `infojsonPreambleLines` lines before the actual layout data starts
                                 //         │                                 ┌ 6+keys because that's the last line that should have a comma
                                 //         ↓                                 ↓
-                                if ( ( n > infojsonPreambleLines ) && ( n < 9+keyCount ) ) {
-                                    insLine.innerHTML = line.replace(/^{\"label/, " ".repeat(16) + "{\"label" ).replace(/\},/g, "},") +"\n";
+                                if ( ( n > infojsonPreambleLines ) && ( n < infojsonPreambleLines+keyCount ) ) {
+                                    insLine.innerHTML = line.replace(/\},/g, "},") +"\n";
                                 } else /* if ( n == 9+keys ) */ {
-                                    insLine.innerHTML = line.replace(/^{\"label/, " ".repeat(16) + "{\"label" ).replace(/(\{\"label.*\}),/g, "$1") +"\n";
+                                    // remove the trailing comma on the last key's JSON object
+                                    insLine.innerHTML = line.replace(/(\{\"label.*\}),/g, "$1") +"\n";
                                 }
                                 preElement.appendChild( insLine );
                             }

--- a/showOutput3.js
+++ b/showOutput3.js
@@ -1002,6 +1002,8 @@ document.getElementById('submit').addEventListener(
             "            \"layout\": ["
         ];
 
+        // How many lines is the info.json "preamble"?
+        var infojsonPreambleLines = infojsonOutput.length;
 
         /****************************
         ** CREATE LAYOUT CONTAINER **
@@ -1132,8 +1134,8 @@ document.getElementById('submit').addEventListener(
             if ( keyObjects[key][3] == 1 ) {
                 infojsonOutputArray.splice(3, 1);
             }
-            // key output starts at line 10
-            infojsonOutput[key+9] = "{" + infojsonOutputArray.join(', ') +
+            // key output starts at `infojsonPreambleLines`+1
+            infojsonOutput[key+infojsonPreambleLines] = "{" + infojsonOutputArray.join(', ') +
                 /*[
                     "\"label\":\""+ keyObjects[key][2] +"\"",
                     "\"x\":"+ keyObjects[key][1],
@@ -1250,10 +1252,10 @@ document.getElementById('submit').addEventListener(
                                 var insLine = document.createElement('code');
                                 preElement.setAttribute('class', "language-json");
                                 // Only output a comma at the end of the line if there's another key object to add
-                                //         ┌ Offset 9 because there are 9 lines before the actual layout data starts
-                                //         │             ┌ 9+keys because that's the last line that should have a comma
-                                //         ↓             ↓
-                                if ( ( n > 9 ) && ( n < 9+keyCount ) ) {
+                                //         ┌ there are `infojsonPreambleLines` lines before the actual layout data starts
+                                //         │                                 ┌ 6+keys because that's the last line that should have a comma
+                                //         ↓                                 ↓
+                                if ( ( n > infojsonPreambleLines ) && ( n < 9+keyCount ) ) {
                                     insLine.innerHTML = line.replace(/^{\"label/, " ".repeat(16) + "{\"label" ).replace(/\},/g, "},") +"\n";
                                 } else /* if ( n == 9+keys ) */ {
                                     insLine.innerHTML = line.replace(/^{\"label/, " ".repeat(16) + "{\"label" ).replace(/(\{\"label.*\}),/g, "$1") +"\n";

--- a/showOutput3.js
+++ b/showOutput3.js
@@ -1009,12 +1009,14 @@ document.getElementById('submit').addEventListener(
         ** CREATE LAYOUT CONTAINER **
         ****************************/
         //var layoutMacro = new Array( keymapHeight );
-        var layoutMacro = "    ";
+        var layoutMacro = "     \\";
+        /*
         for ( i=0 ; i<keymapHeight; i++ ) {
-            layoutMacro += " \\";
+            layoutMacro += "";
         }
+        */
         var layoutMacro_rowOffset = ( keymapWidth * 5 ) + 5;
-        //console.log( layoutMacro );
+        console.log( layoutMacro );
 
         /*******************************
         ** CREATE info.json STRUCTURE **
@@ -1032,10 +1034,12 @@ document.getElementById('submit').addEventListener(
             // Electrical Data
             var pinRow = obj.keyboard.pins.row[obj.keyboard.keys[key].row];
             var pinCol = obj.keyboard.pins.col[obj.keyboard.keys[key].col];
-            var label = ["K", base32hex.substr(obj.keyboard.keys[key].row, 1), base32hex.substr(obj.keyboard.keys[key].col, 1)].join('') + " ("+ [pinRow,pinCol].join(',') +")";
+            var label = ["K", base32hex.substr(obj.keyboard.keys[key].row, 1), base32hex.substr(obj.keyboard.keys[key].col, 1)].join('');
+            var pins = [pinRow,pinCol].join(',');
 
             keyObject = new Array(
                 '"label": "'+ label +'"',
+                '"pins": "'+ pins +'"',
                 '"seq": "'+ key +'"',
                 '"x": '+ x,
                 '"y": '+ y,
@@ -1043,40 +1047,20 @@ document.getElementById('submit').addEventListener(
                 '"h": '+ h
             );
 
+            // Remove width and/or height keys if value is equal to 1
             if ( h == 1 ) {
-                keyObject.splice(5, 1);
+                keyObject.splice(6, 1);
             }
             if ( w == 1 ) {
-                keyObject.splice(4, 1);
+                keyObject.splice(5, 1);
             }
 
-            //console.log( keyObject.join('\t') );
             keyObjects[key] = keyObject.join('\t');
 
             infojsonOutput.push(
                 " ".repeat(16) + "{" + keyObject.join(', ') + "},"
             );
-
-            if ( w != 1 ) {
-                infojsonOutput[infojsonOutput.length-1] = infojsonOutput[infojsonOutput.length-1].replace(/},$/g, ", \"w\":"+ w +"},");
-            }
-            if ( h != 1 ) {
-                infojsonOutput[infojsonOutput.length-1] = infojsonOutput[infojsonOutput.length-1].replace(/},$/g, ", \"h\":"+ h +"},");
-            }
         }
-        /*
-        for ( row=0; row<keymapHeight; row++ ) {
-            console.log( row +" of "+ keymapHeight );
-            for ( col=0; col<keymapWidth; col++ ) {
-                layoutMacro[row][col] = ["P", base32hex.substr( row, 1), base32hex.substr( col, 1)].join('');
-            }
-        }
-        */
-        /*console.log(
-                "Layout Macro: ("+ keymapHeight +"x"+ keymapWidth +")\n"+
-                "=".repeat(20) +"\n"+
-                layoutMacro
-        );*/
 
         var keymapRowText = "";
         var keymapLayer = "";
@@ -1097,23 +1081,13 @@ document.getElementById('submit').addEventListener(
                         km_layer_row.join(', ');
                     }
                 );
-                //km_layer.join('  ),\n  ');
             }
         );
         keymap = keymap.join('\n\n\n');
-        /*
-            "  ["+ layer +"] = LAYOUT( \\\n"
-              text of keymap layer
-            "  ),"
-        */
-
-        keyObjects.sort();
 
         for ( key=0; key<keyCount; key++ ) {
             keyObjects[key] = keyObjects[key].split('\t');
-            keyObjects[key].splice(0, 1);
-            keyObjects[key][0] = Number( keyObjects[key][0] ) + Number( keyObjects[key][2] );
-            keyObjects[key].splice(2, 1);
+            var newRow = [];
 
             if ( key == ( keyCount-1 ) ) {
             }
@@ -1128,20 +1102,20 @@ document.getElementById('submit').addEventListener(
                     ( keyObjects[key][1] * 5 ) + Math.round( keyObjects[key][3] * 2 )
                 );
             } else {
-                //layoutMacro_start = ( Number( Math.round( keyObjects[key][0] ) * layoutMacro_rowOffset ) + ( keyObjects[key][1] * 5 ) );
-                layoutMacro += keyObjects[key][0];
+                layoutMacro = layoutMacro.replace(
+                    "\\",
+                    keyObjects[key][0].split(':')[1].replace(/[" ]/g, "") + ", \\"
+                );
             }
-            //layoutMacro_end = Number(layoutMacro_start + 5);
-            //layoutMacro = layoutMacro.replaceBetween( layoutMacro_start, layoutMacro_end, keyObjects[key][2].replace(/ \(.*/, "")+", " );
+            if ( key > 0 ) {
+                if ( keyObjects[key][4] > keyObjects[key-1][4] ) {
+                    if ( keyObjects[key][3] < keyObjects[key-1][3] ) {
+                        newRow.push( keyObjects[key][0] );
+                    }
+                }
+            }
+            console.log( newRow.join('; ') );
         }
-        //console.log( "^" + layoutMacro + "$" );
-        //layoutMacro = "    "+ layoutMacro
-            /*.replace(/,( +)\\$/g, " $1\\")
-            .replace(/\\/g, "\\\n    ")
-            .replace(/\\\n    $/g, "\\")
-            .replace(/  \\/g, "\\")*/
-        ;
-        //physicalMatrix = physicalMatrix.replace(/, \\$/, "")
 
         infojsonOutput.push(
             "            ]",


### PR DESCRIPTION
Rewrote the `keymap.c`, `keyboard.h` and `info.json` generation routines to play nice with miniature key sizes.

## Issues Fixed

* fixes #6

## Regression

* layout macro arguments and keycode arguments are no longer horizontally aligned to mimic the physical layout of the keyboard.